### PR TITLE
feat(ch6): add Chapter 6 — The West Coast Years (Vancouver)

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -68,7 +68,8 @@ Chapter flow lives in `v1-modern/src/scripts/game.narrat`. `main:` shows a title
 2. **Ch 2 · The Sunset Walk** — `sunset_scene` (preset: knows_name, talked_business/artist, has_shekel, can_go_sunset)
 3. **Ch 3 · Jaffa Nights** — `jaffa_apt_scene` (preset: all Ch 2 flags + sunset topics + can_fly + agreed_to_travel)
 4. **Ch 4 · Kyoto Kitchen** — `japan_scene` → `kyoto_apt_scene` → `kitchen_scene` (preset: all Ch 3 + slept_with_k + has_kite)
-5. **Ch 5 · Forever Home** — `home_scene` (the sacred-line scene)
+5. **Ch 5 · Forever Home** — `home_scene` (the sacred-line scene — terminates cleanly after "For Anastasia. Forever.")
+6. **Ch 6 · The West Coast Years (Epilogue)** — `vancouver_intro` → `vancouver_apt_scene` → `vancouver_day_prompt` (4-topic cascade: trails, squamish-kite, north-van-persian, costco) → `vancouver_outro`. Accessed via `chapter_select` only; does **not** play after Ch 5 in the main flow (sacred-line constraint). Chronologically: years after Ch 5.
 
 ### 6. Known-good commands
 

--- a/v1-modern/public/data/config.yaml
+++ b/v1-modern/public/data/config.yaml
@@ -20,6 +20,13 @@ common:
     kyoto_apt: img/kyoto_apt.png
     kitchen: img/kitchen.png
     home: img/home.png
+    # Chapter 6 placeholders — real art TBD via art-director → game-artist
+    kits_beach: img/beach_rest.png
+    vancouver_apt: img/kyoto_apt.png
+    vancouver_peak: img/sunset.png
+    squamish: img/beach.png
+    north_van_persian: img/kitchen.png
+    costco_downtown: img/home.png
   hudStats: {}
 
 dialoguePanel:
@@ -58,6 +65,18 @@ screens:
       background: kitchen
     home:
       background: home
+    kits_beach:
+      background: kits_beach
+    vancouver_apt:
+      background: vancouver_apt
+    vancouver_peak:
+      background: vancouver_peak
+    squamish:
+      background: squamish
+    north_van_persian:
+      background: north_van_persian
+    costco_downtown:
+      background: costco_downtown
 
 characters:
   config:

--- a/v1-modern/src/config/scripts.ts
+++ b/v1-modern/src/config/scripts.ts
@@ -3,5 +3,6 @@ import beach from '../scripts/beach.narrat';
 import sunset from '../scripts/sunset.narrat';
 import jaffa from '../scripts/jaffa.narrat';
 import japan from '../scripts/japan.narrat';
+import vancouver from '../scripts/vancouver.narrat';
 
-export default [game, beach, sunset, jaffa, japan];
+export default [game, beach, sunset, jaffa, japan, vancouver];

--- a/v1-modern/src/scripts/game.narrat
+++ b/v1-modern/src/scripts/game.narrat
@@ -19,6 +19,8 @@ chapter_select:
       jump chapter_4_start
     "Chapter 5 · Forever Home":
       jump chapter_5_start
+    "Chapter 6 · The West Coast Years (Epilogue)":
+      jump chapter_6_start
 
 chapter_1_start:
   "Chapter 1 — Meet Cute"
@@ -92,6 +94,12 @@ chapter_5_start:
   "Back in Tel Aviv. The balcony. Two cups of tea."
   ""
   jump home_scene
+
+chapter_6_start:
+  "Chapter 6 — The West Coast Years"
+  "Years after Tel Aviv. Vancouver. The story keeps going."
+  ""
+  jump vancouver_intro
 
 intro_scene:
   "The tales of P."

--- a/v1-modern/src/scripts/vancouver.narrat
+++ b/v1-modern/src/scripts/vancouver.narrat
@@ -1,0 +1,97 @@
+vancouver_intro:
+  set_screen kits_beach
+  "KITS BEACH. Cold wet sand. Cedar on the wind. Not Tel Aviv."
+  "You miss the salt-warm. Then you don't."
+  talk k idle "Told you it'd feel like home, P. Just colder."
+  talk phoenix idle "The water's glass today. I can feel SQUAMISH already."
+  "Years after Tel Aviv. VANCOUVER, now. Inseparable, still."
+  jump vancouver_apt_scene
+
+vancouver_apt_scene:
+  set_screen vancouver_apt
+  "Your place. High ceilings. Two desks back-to-back, facing the water."
+  "On your screen: a FIFA striker mid-sprint, rendered polygon by polygon."
+  talk phoenix idle "TTTC taught me the ropes. Now I'm pushing pixels for EA — FC 26."
+  talk k idle "Meanwhile my coder AGENTS are refactoring while I make coffee."
+  talk k idle "I lead. They build. That's AI-first — the future of shipping code."
+  "The cursor blinks. Somewhere in the stack, a commit lands."
+  run trigger_easter_egg pnk_love
+  jump vancouver_day_setup
+
+vancouver_day_setup:
+  set data.did_trails false
+  set data.did_squamish false
+  set data.did_persian false
+  set data.did_costco false
+  jump vancouver_day_prompt
+
+vancouver_day_prompt:
+  choice:
+    "What do you two want to do today?"
+    "Hit the TRAILS — hike or BOARD":
+      jump did_trails
+    "SQUAMISH — go KITE":
+      jump did_squamish
+    "FESENJAN in North Van":
+      jump did_persian
+    "COSTCO run downtown":
+      jump did_costco
+    "Head home":
+      jump vancouver_outro
+
+did_trails:
+  if $data.did_trails:
+    jump did_squamish
+  set_screen vancouver_peak
+  talk k idle "The TRAIL loop above Lions Gate. BOARD or boots — your call."
+  "You hike the ridge when the snow's gone, carve it when it's in."
+  "Cedars dripping. PEAK above. City glittering somewhere below."
+  "MAPLE leaf pressed flat on the path. You pocket it."
+  set data.did_trails true
+  jump vancouver_day_prompt
+
+did_squamish:
+  if $data.did_squamish:
+    jump did_persian
+  set_screen squamish
+  talk phoenix idle "Wind's up. I'm going."
+  talk k idle "Go FLY. I'll watch from the shore."
+  "You unfurl the KITE. Phoenix wings, human harness — old grammar, new language."
+  "K. settles on a driftwood log at the edge of Howe Sound, eyes tracking you."
+  "Inseparable, even when one of you is in the air."
+  run trigger_easter_egg pnk_fly
+  set data.did_squamish true
+  jump vancouver_day_prompt
+
+did_persian:
+  if $data.did_persian:
+    jump did_costco
+  set_screen north_van_persian
+  "A small NORTH VAN restaurant. Saffron light. ROSEWATER in the air."
+  talk k idle "FESENJAN tonight. And crispy TAHDIG — the crust's the whole point."
+  "Walnut. Pomegranate. Slow-cooked for hours."
+  "You share. You always share."
+  set data.did_persian true
+  jump vancouver_day_prompt
+
+did_costco:
+  if $data.did_costco:
+    jump vancouver_outro
+  set_screen costco_downtown
+  "COSTCO. Downtown. A fluorescent cathedral of bulk."
+  talk phoenix idle "Bulk MANGO. Bulk TEA. Bulk LOVE."
+  talk k idle "That's not a product, P."
+  talk phoenix idle "Tell that to my cart."
+  "You leave with three of everything. Somehow that's romance, now."
+  set data.did_costco true
+  jump vancouver_day_prompt
+
+vancouver_outro:
+  set_screen vancouver_apt
+  "Evening. The apartment. Light on the water, thirty floors down."
+  talk k idle "Tel Aviv light. Kyoto light. Vancouver light. All of it, one long day."
+  talk phoenix idle "One long forever."
+  ""
+  "..."
+  ""
+  "And the story keeps going."


### PR DESCRIPTION
Adds **Chapter 6 · The West Coast Years** as a post-sacred epilogue accessible via `chapter_select`. Implements [#11](https://github.com/wildcard/pnk-forever/issues/11) with maintainer-confirmed beats.

## Maintainer answers (locked)

1. **Timeline:** years after Tel Aviv (Ch 5). Not right after Kyoto.
2. **EA Sports title:** FIFA, specifically **FC 26**.
3. **Kitesurfing:** P. kites solo, K. is **shore-side** — inseparable, watching.

## Chapter flow

```
chapter_6_start → vancouver_intro (Kits Beach arrival)
              → vancouver_apt_scene (P.'s FC 26 render + K.'s coder agents)
              → vancouver_day_setup (flag init)
              → vancouver_day_prompt ←────┐
                   ├─ did_trails          │
                   ├─ did_squamish        │  cascade with guards
                   ├─ did_persian         │  (pattern a, 4 topics)
                   ├─ did_costco          │
                   └─ Head home ──────────┘→ vancouver_outro
```

## What ships

| File | Change |
|---|---|
| `v1-modern/src/scripts/vancouver.narrat` | **NEW** — entire Ch 6 script |
| `v1-modern/src/config/scripts.ts` | Import + register the new file |
| `v1-modern/src/scripts/game.narrat` | Add \`chapter_6_start\` label + \`chapter_select\` entry |
| `v1-modern/public/data/config.yaml` | 6 new screens mapped to placeholder art |
| `HANDOVER.md` §5 | Chapter list now lists Ch 6 with cascade topology |

## Sacred-line invariant

**Ch 5's \`home_scene\` is untouched.** \"For Anastasia. Forever.\" remains the last line of Ch 5 and terminates the scene cleanly. Main flow still ends there. Ch 6 is chapter-select-only — a player who wants the epilogue opts into it; the emotional terminus of the gift does not move.

Verified: bundle contains \"For Anastasia. Forever.\" **exactly once**.

## Loop-safety — rule-compliant

Per [\`.claude/rules/narrat-no-autoplay-loops.md\`](.claude/rules/narrat-no-autoplay-loops.md):

- **Pattern (a) cascade via guard** — every did_* sub-label starts with \`if \$data.did_*: jump <next_topic>\`; body sets flag and returns to parent.
- **4 cascade topics + 1 exit option = 5 total prompt visits max** (first-option autoplay AND rotating-choice strategy both terminate in ≤5 visits). 1-visit buffer under the 6-visit ship-gate cap.
- **Diagnostic grep before push:** zero NEW self-jumps in \`vancouver.narrat\`. Pre-existing hits in \`beach.narrat\`/\`sunset.narrat\` remain under [#5](https://github.com/wildcard/pnk-forever/issues/5) scope.

## Beats woven from the brief

| Brief element | Where in Ch 6 |
|---|---|
| After Tel Aviv | \`vancouver_intro\` opening narration |
| FIFA / FC 26 | \`vancouver_apt_scene\` — P.'s monitor |
| TTTC (Think Tank Training Centre) | \`vancouver_apt_scene\` — P.'s credentials |
| EA Sports | Same beat |
| K. leading AI-first dev + coder agents | \`vancouver_apt_scene\` — K.'s half of the desk |
| Hiking + snowboarding | \`did_trails\` (folded into one flag for loop budget) |
| Kitesurfing Squamish | \`did_squamish\` — P. flies, K. shore-side |
| Kits Beach | \`vancouver_intro\` + \`did_trails\` screen |
| Trails everywhere | \`did_trails\` |
| North Van Persian food | \`did_persian\` — fesenjan, tahdig, rosewater |
| Downtown food scene + Costco | \`did_costco\` — \"fluorescent cathedral\" |
| Inseparable | \`vancouver_intro\` closer + Squamish shore beat + \"You share. You always share.\" |

## New easter-egg keyword candidates

\`VANCOUVER\` · \`KITS\` · \`SQUAMISH\` · \`FIFA\` · \`FC 26\` · \`TTTC\` · \`EA\` · \`AGENTS\` · \`MAPLE\` · \`TRAIL\` · \`BOARD\` · \`PEAK\` · \`FESENJAN\` · \`TAHDIG\` · \`ROSEWATER\` · \`COSTCO\`

Preserved callbacks (appear again, don't need new registration): \`KITE\`, \`FLY\`, \`MANGO\`, \`TEA\`, \`LOVE\`.

**Centralization pending** — [#6](https://github.com/wildcard/pnk-forever/issues/6) should absorb these into the single source of truth when it lands.

## Art — placeholder only

New screens mapped to existing backgrounds as temporary stand-ins:

| Ch 6 screen | Placeholder |
|---|---|
| \`kits_beach\` | \`img/beach_rest.png\` |
| \`vancouver_apt\` | \`img/kyoto_apt.png\` |
| \`vancouver_peak\` | \`img/sunset.png\` |
| \`squamish\` | \`img/beach.png\` |
| \`north_van_persian\` | \`img/kitchen.png\` |
| \`costco_downtown\` | \`img/home.png\` |

**Follow-up PR:** dispatch \`art-director\` → \`game-artist\` to render 6 new backgrounds via Gemini nano banana. Same style as existing chapters.

## Verification

```bash
# Build
cd v1-modern && npm run build
# ✓ vite build succeeded, narrat parser accepted script

# Sacred line still exactly once
grep -c \"For Anastasia. Forever.\" v1-modern/dist/assets/*.js
# ✓ 1

# Ch 6 content in bundle
grep -o \"The story keeps going\" v1-modern/dist/assets/*.js
# ✓ The story keeps going

# Diagnostic self-jump grep
# ✓ zero NEW hits in vancouver.narrat
```

## Related

- Closes a significant portion of [#11](https://github.com/wildcard/pnk-forever/issues/11) (the Ch 6 design doc — this PR is the first narrative pass)
- Art follow-up will close the rest
- Does not block [#10](https://github.com/wildcard/pnk-forever/issues/10) (K. sprite Black-and-Tan fix) or Phase A issues [#3](https://github.com/wildcard/pnk-forever/issues/3)/[#4](https://github.com/wildcard/pnk-forever/issues/4)/[#5](https://github.com/wildcard/pnk-forever/issues/5)/[#6](https://github.com/wildcard/pnk-forever/issues/6); those remain prerequisites for v1.0.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)