### PR TITLE
feat(tester): add ?tester=1 escape hatch to chapter_select

### DIFF
--- a/HANDOVER.md
+++ b/HANDOVER.md
@@ -150,6 +150,25 @@ Build only ships when **every** criterion is green (game-tester enforces):
 
 ### 11. Open work (in priority order)
 
+0. **Tester escape hatch — shipped.** Append `?tester=1` to any deploy URL
+   (e.g. `https://pnk-forever.vercel.app/?tester=1` or
+   `http://localhost:8765/?tester=1`) to:
+   - skip the linear prologue and land directly on `chapter_select`
+     (all 5 chapters pickable),
+   - show narrat's built-in **Debug Menu** (jump-to-label, skip, data
+     inspector),
+   - render a visible orange **"TESTER MODE · ?tester=1"** ribbon in the
+     top-right so the tester never confuses test-mode with the real player
+     flow.
+
+   A regular URL has zero change: `tester_route` runs as a no-op, the VM
+   advances through the narrator lines and jumps to `chapter_1_start`. The
+   plugin lives in `v1-modern/src/plugins/tester-plugin.ts`; it is invoked
+   from `game.narrat:main` as the bare keyword `tester_route` (NOT
+   `run tester_route` — narrat's built-in `run` calls scripted labels, not
+   custom plugin commands). See the file's header comment for the
+   lifecycle rationale (why a `CommandPlugin` beats `startMenuButtons`).
+
 1. **Volume-select UI** (partially scoped, not shipped). The user wants a volume picker BEFORE chapter-select. Implementation plan:
    - Register a narrat plugin in `v1-modern/src/index.ts` that adds a `CommandPlugin` with keyword `open_url` (one string arg) — runner sets `window.location.href`.
    - Add `volume_select:` label in `game.narrat` between `main:` and `chapter_select:`:

--- a/v1-modern/src/index.ts
+++ b/v1-modern/src/index.ts
@@ -2,12 +2,24 @@ import { startApp } from 'narrat';
 import 'narrat/dist/style.css';
 import './game.css';
 import scripts from './config/scripts';
+import {
+  isTesterMode,
+  mountTesterRibbon,
+  registerTesterPlugin,
+} from './plugins/tester-plugin';
+
+// Register plugins BEFORE startApp so their customCommands are available when
+// the VM parses scripts (the narrat parser rejects unknown keywords).
+registerTesterPlugin();
+
+const testerMode = isTesterMode();
 
 window.addEventListener('load', () => {
+  mountTesterRibbon();
   startApp({
     configPath: 'data/config.yaml',
-    logging: false,
-    debug: false,
+    logging: testerMode,
+    debug: testerMode,
     container: '#app',
     scripts,
   });

--- a/v1-modern/src/plugins/tester-plugin.ts
+++ b/v1-modern/src/plugins/tester-plugin.ts
@@ -1,0 +1,112 @@
+/**
+ * PNK Forever — Tester escape hatch
+ *
+ * Registers a narrat `CommandPlugin` that exposes one scripting command:
+ *
+ *   tester_route
+ *
+ * Invoked directly as a top-level command in `main:` (NOT via `run` — narrat's
+ * built-in `run` keyword calls scripted labels, while `registerPlugin({
+ * customCommands: [...] })` adds our keyword to the parser's root vocabulary).
+ *
+ * When the URL contains `?tester=1`, calling `tester_route` from `main:` jumps
+ * the VM to the `chapter_select` label so the tester can pick any of the five
+ * chapters (plus the Ch 6 epilogue). When the URL has no tester flag, the
+ * command is a no-op — a regular player experiences zero change.
+ *
+ * Design notes
+ * ------------
+ * - We intentionally do NOT modify the start menu. `startMenuButtons` fires
+ *   before the VM has a running frame, so calling `useVM().jumpToLabel()`
+ *   from a button action is a lifecycle race. Putting the tester check inside
+ *   `main:` via `run tester_route` runs *after* the VM is initialized — no
+ *   races, no DOM hacks.
+ * - Companion to this plugin: `index.ts` flips `debug: true` on the same URL
+ *   flag so testers also get narrat's built-in developer panel (jump-to-label,
+ *   skip, data inspector). The panel is auto-hidden in production builds
+ *   unless the flag opts in.
+ *
+ * See also:
+ *   - https://docs.narrat.dev/guides/custom-start-buttons.html
+ *   - https://docs.narrat.dev/plugins/plugins.html
+ *   - `.claude/rules/narrat-no-autoplay-loops.md` (the loop invariant)
+ */
+import { CommandPlugin, registerPlugin, useVM } from 'narrat';
+
+const TESTER_QUERY_KEY = 'tester';
+const TESTER_QUERY_VALUE = '1';
+const TESTER_TARGET_LABEL = 'chapter_select';
+
+/**
+ * True if the URL carries `?tester=1`. Cheap to call — reads `location.search`
+ * fresh each time so deep-links still work if the param is added mid-session.
+ */
+export function isTesterMode(): boolean {
+  if (typeof window === 'undefined') return false;
+  const params = new URLSearchParams(window.location.search);
+  return params.get(TESTER_QUERY_KEY) === TESTER_QUERY_VALUE;
+}
+
+/**
+ * Registers the tester plugin with narrat. Safe to call every boot — the
+ * `tester_route` command itself guards on `isTesterMode()`, so a normal
+ * player's run-time cost is one function call that returns immediately.
+ */
+export function registerTesterPlugin(): void {
+  const testerRoute = new CommandPlugin<{}, {}>(
+    'tester_route',
+    [], // no args
+    async () => {
+      if (!isTesterMode()) return;
+      // Fire-and-forget: jumpToLabel sets jumpTarget on the VM, which the
+      // outer run loop picks up on its next tick and uses to replace the
+      // current frame. The remaining commands in `main:` (the narrator
+      // lines + the `jump chapter_1_start`) are discarded.
+      await useVM().jumpToLabel(TESTER_TARGET_LABEL);
+    },
+  );
+
+  registerPlugin({
+    pluginId: 'pnk-tester',
+    customCommands: [testerRoute],
+  });
+}
+
+/**
+ * Mounts a small fixed-position ribbon so testers can see at a glance that
+ * they're in tester mode and are not looking at the real player flow.
+ * Inert — no clicks, no narrative impact.
+ */
+export function mountTesterRibbon(): void {
+  if (!isTesterMode()) return;
+  if (typeof document === 'undefined') return;
+  if (document.getElementById('pnk-tester-ribbon')) return;
+
+  const ribbon = document.createElement('div');
+  ribbon.id = 'pnk-tester-ribbon';
+  ribbon.textContent = 'TESTER MODE · ?tester=1';
+  Object.assign(ribbon.style, {
+    position: 'fixed',
+    top: '0',
+    right: '0',
+    zIndex: '99999',
+    padding: '4px 12px',
+    background: 'rgba(255, 107, 53, 0.92)', // Phoenix orange
+    color: 'white',
+    fontFamily: 'monospace',
+    fontSize: '11px',
+    letterSpacing: '0.08em',
+    borderBottomLeftRadius: '6px',
+    pointerEvents: 'none',
+    textShadow: '0 1px 2px rgba(0,0,0,0.4)',
+  } as Partial<CSSStyleDeclaration>);
+
+  // Defer until document.body exists.
+  if (document.body) {
+    document.body.appendChild(ribbon);
+  } else {
+    window.addEventListener('DOMContentLoaded', () => {
+      document.body.appendChild(ribbon);
+    });
+  }
+}

--- a/v1-modern/src/scripts/game.narrat
+++ b/v1-modern/src/scripts/game.narrat
@@ -1,10 +1,9 @@
 main:
   set_screen beach_rest
+  tester_route
   "P. & K. — A Love Story in Two Volumes"
   ""
   jump chapter_1_start
-
-# chapter_select kept for testing/QA — not in main player flow
 
 chapter_select:
   choice:


### PR DESCRIPTION
`[agent]`

**Agent:** Claude Code (`claude-sonnet-4-6`)

---

## Why

Testers need to reach every chapter quickly without playing the linear prologue each run. Previously the only route into Ch 2–5 was the narrative chain starting at `chapter_1_start`, which made bisecting ship-gate bugs (loop regressions, asset misses, sacred-line integrity) slow and noisy.

## What shipped

A URL-gated **tester escape hatch**. Append `?tester=1` to any deploy URL to get three synchronized affordances:

1. **Jump to `chapter_select`** — skips the prologue, lands on the picker with all 5 chapters available (pre-seeded flag state already exists per `chapter_N_start` labels).
2. **Narrat's built-in Debug Menu** — jump-to-label, skip, data inspector. Now conditionally enabled via `debug`/`logging` in `startApp()`.
3. **Orange "TESTER MODE" ribbon** — fixed-position, top-right, inert. Makes it obvious which mode the tester is in, so nobody mistakes test-mode output for player-mode output.

Without the flag: zero change. The `tester_route` runner short-circuits, `main:` plays through to `chapter_1_start`, no ribbon, no debug menu.

## Design notes

- **`CommandPlugin` over `startMenuButtons`**: button actions fire before the VM has a running frame, so calling `useVM().jumpToLabel()` from one races the VM's bootstrap. Putting the tester check inside `main:` via a custom command runs *after* the VM is initialized — no race, no DOM hack.
- **Bare keyword, not `run tester_route`**: narrat's built-in `run` is the label-runner; it 404s on plugin keywords. Custom plugin commands registered via `registerPlugin({ customCommands })` join the parser's root vocabulary and are invoked on their own line, just like `set`, `talk`, `jump`.
- **HANDOVER.md §11.0** documents the URL flag, the three affordances, and the narrat gotcha, so the next agent doesn't re-discover the `run`-vs-bare-keyword distinction the hard way.

## Verification

Playwright against local build (`npm run build && npx serve -l 8765 dist`):

| URL | Expected | Result |
|---|---|---|
| `/?fresh=1` | Press to start → New Game → **Ch 1 intro**, no ribbon, no debug menu | ✓ PASS |
| `/?tester=1` | Press to start → New Game → **`chapter_select`** with 5 chapters, orange ribbon, Debug Menu button | ✓ PASS |

Zero `console.error` in either run.

## Files touched

- **new** `v1-modern/src/plugins/tester-plugin.ts` — `isTesterMode()`, `registerTesterPlugin()`, `mountTesterRibbon()`
- `v1-modern/src/index.ts` — register plugin before `startApp`; gate `debug`/`logging` on the URL flag; mount ribbon on `load`
- `v1-modern/src/scripts/game.narrat` — add `tester_route` as the first executable command in `main:`
- `HANDOVER.md` — new §11.0 documenting the URL, affordances, and narrat-syntax gotcha

---

<details>
<summary>Prompt used to generate this comment</summary>

```
User ask: "allow a tester to test all the available chapters with a escape hatch that doesn't ruin the game narrtive (search for documneted narrat solutions)"
```

</details>