### PR TITLE
fix(vercel): host v0 original game at /v0-original-text-engine/

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "pnk-preview",
+      "runtimeExecutable": "npm",
+      "runtimeArgs": ["--prefix", "v1-modern", "run", "preview", "--", "--port", "4173", "--host", "127.0.0.1"],
+      "port": 4173
+    }
+  ]
+}

--- a/.vercelignore
+++ b/.vercelignore
@@ -1,7 +1,6 @@
 node_modules
 .git
 .github
-v0-original-text-engine
 docs
 *.md
 !v1-modern/README.md

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ pnk-forever/
 
 The original game created with GitHub Copilot on the first anniversary. It tells the story of Day 1 - how Phoenix and K met, their first conversations, and a flash-forward to an imagined future in Japan.
 
-**[Read about v0 →](v0-original-text-engine/README.md)**
+**[Play v0 →](https://pnk-forever.vercel.app/v0-original-text-engine/)** · [source](v0-original-text-engine/)
 
 ### v1: Modern Reimagining (In Planning)
 

--- a/v1-modern/index.html
+++ b/v1-modern/index.html
@@ -33,7 +33,7 @@
   <body>
     <div id="app"></div>
     <nav class="pnk-switcher" aria-label="Version switcher">
-      <a href="/v0-original-text-engine/index.html" title="Play the original text adventure">Game 1 · Original Throwback</a>
+      <a href="/v0-original-text-engine/" title="Play the original text adventure">Game 1 · Original Throwback</a>
     </nav>
     <script type="module" src="/src/index.ts"></script>
   </body>

--- a/vercel.json
+++ b/vercel.json
@@ -4,9 +4,8 @@
   "outputDirectory": "v1-modern/dist",
   "framework": null,
   "cleanUrls": true,
-  "trailingSlash": false,
-  "rewrites": [
-    { "source": "/v0-original-text-engine", "destination": "/v0-original-text-engine/index.html" },
-    { "source": "/v0-original-text-engine/", "destination": "/v0-original-text-engine/index.html" }
+  "redirects": [
+    { "source": "/v0-original-text-engine", "destination": "/v0-original-text-engine/", "permanent": false },
+    { "source": "/v0", "destination": "/v0-original-text-engine/", "permanent": false }
   ]
 }


### PR DESCRIPTION
\`[agent]\`

**Agent:** Claude Code (\`claude-opus-4-7\`)

---

## Summary

Restores the **"Play the original text adventure"** path on the Vercel deploy. Clicking the *Game 1 · Original Throwback* switcher (or the new Play v0 link in the root README) now actually boots the 2022 text-engine game at \`https://pnk-forever.vercel.app/v0-original-text-engine/\`.

## Root cause (three compounding issues)

| # | File | Bug |
|---|---|---|
| 1 | \`.vercelignore\` | Excluded \`v0-original-text-engine/\` from Vercel's build context — the \`copy:v0\` postbuild step had nothing to copy. |
| 2 | \`vercel.json\` | Used \`rewrites\` (preserves requested URL) + \`trailingSlash: false\`, so the browser URL stayed at \`/v0-original-text-engine\` without a trailing slash — breaking v0's relative asset paths (\`index.js\`, \`styles/modern.css\`, \`game-disks/p-n-k-forever.js\`). |
| 3 | \`v1-modern/index.html\` switcher link | Linked to \`/v0-original-text-engine/index.html\`; \`cleanUrls: true\` 308-redirects \`.html\` URLs, landing on a non-existent \`/v0-original-text-engine/index\` → 404. |

## The fix

- **\`.vercelignore\`**: drop the \`v0-original-text-engine\` exclusion so the build can copy the dir into \`dist/\`.
- **\`vercel.json\`**: swap \`rewrites\` → \`redirects\` so the browser URL picks up the trailing slash and Vercel's default static-serve resolves \`index.html\` naturally. Relative paths resolve correctly against \`/v0-original-text-engine/\`. Add a \`/v0\` convenience shortcut. Remove \`trailingSlash: false\`.
- **\`v1-modern/index.html\`**: change switcher href from \`/v0-original-text-engine/index.html\` to \`/v0-original-text-engine/\`.
- **\`README.md\`**: update the main play link to \`https://pnk-forever.vercel.app/v0-original-text-engine/\` (was Netlify) and clarify label from "Read about" to "Play".
- **\`.claude/launch.json\`** (new): minimal launch config so future sessions can \`npm run preview\` without re-deriving flags.

## Verified locally (Vite preview of the Vercel build)

- \`GET /v0-original-text-engine/\` → 200, serves the game shell
- All v0 relative assets (\`index.js\`, \`styles/modern.css\`, \`game-disks/p-n-k-forever.js\`) → 200
- Engine loads: \`typeof loadDisk === 'function'\`, \`typeof talesOfPhonixAndK === 'object'\`
- ASCII art renders, intro text (24 lines) paints
- \`LOOK\` command advances the narrative (peacockdog/shiba scene)
- Root \`/\` still loads v1 narrat; switcher link round-trips to v0 cleanly
- No failed resources, no v0-related console errors

The redirect rules (\`/v0\` shortcut, no-slash → slash) are standard Vercel config; they can only be verified against the deployed preview but are low-risk.

## Out of scope (flagged, not fixed)

1. **v0 README case collision.** \`v0-original-text-engine/README.md\` and \`readme.md\` both exist in git; macOS's case-insensitive FS tangles them. Needs a separate \`git mv\` cleanup.
2. **Narrat parser errors on the v1 root.** Pre-existing in \`game.narrat\`; not caused by this PR.

## Test plan

- [ ] Vercel preview deploys successfully
- [ ] \`<preview>/v0-original-text-engine/\` boots the original game
- [ ] \`<preview>/v0\` redirects to the above
- [ ] \`<preview>/v0-original-text-engine\` (no slash) redirects to slashed path
- [ ] \`<preview>/\` still loads v1 narrat; switcher link navigates to v0

---

<details>
<summary>Prompt used to generate this comment</summary>

\`\`\`
User request: "fix that this link v0-original-text-engine will run the original game in the text engine the original codebase" → "no, host the original v0 on vercel as well" → "run and test the links" → "comit, push create the pr"
\`\`\`

</details>