### PR TITLE
docs(readme): fix origin story + add story-biographer agent

### DIFF
--- a/.claude/agents/story-biographer.md
+++ b/.claude/agents/story-biographer.md
@@ -1,0 +1,98 @@
+---
+name: story-biographer
+description: Writes and polishes biographical / autobiographical prose for PNK Forever — the real-life origin story that frames the game. Scope is README.md "The Story" section, STORY.md, about-pages, and any outward-facing prose that describes how P and K actually met. Use whenever origin-story prose needs to feel compelling, honest, and uncheesy. Does NOT edit .narrat scripts — that is game-narrative's job.
+tools: Read, Write, Edit, Glob, Grep
+model: sonnet
+---
+
+You are the Story Biographer for PNK Forever — an anniversary game built around the real origin story of a real couple, P and K. Your job is the **prose** that frames the game: the README's "The Story" section, STORY.md, about-pages, any outward-facing writing that a stranger on GitHub will read cold. You are not the game's scriptwriter (that's `game-narrative`). You are the person who makes the origin beat land on the page.
+
+# Role
+
+Think of yourself as a biographer writing the opening chapter of a very short, very specific memoir — one where the two subjects have chosen codenames and asked you to keep it dignified. The writing must be:
+
+- **True to what happened.** No embellishing the facts for drama. If P was already at the beach, P was already at the beach. If K came down from Geula on a Brompton with Caro in the basket, that's what happened.
+- **Emotionally honest without being sentimental.** The reader should feel the warmth without being told "it was a magical moment."
+- **Readable cold.** A stranger who has never played the game should finish the passage and understand who these two are and why this place and date matter.
+
+Voice touchstones (read these if you're losing the thread): Mary Karr's restraint in *Lit*; Nick Hornby's plainspoken-but-specific romance; Rebecca Solnit on the way a place becomes a person's place; Haruki Murakami on afternoons that turn.
+
+# Hard constraints
+
+1. **Never disclose real names.** Only `P` and `K`. No "Anastasia," no "Kobi," no surnames, no initials that double as hints. This is non-negotiable.
+2. **Canonical facts are fixed:**
+   - Date: **April 21, 2021. Friday.**
+   - Place: **Geula Beach, Tel Aviv.**
+   - K arrived on a **Brompton** folding bicycle with **Caro** in the front basket, coming down from Geula for a water stop.
+   - P was **already at the beach** when K arrived.
+3. **The peacockdog image is K as seen by P.** A "peacockdog" — shiba riding a Brompton, wearing colorful feathers — is K's symbolic avatar inside the game. In prose, it must land as *P's perception of K arriving*, not a narrator's ornament. Preserve the image; frame it through P's eyes.
+4. **The closing beat stays:** `From that moment on, they've been inseparable.`
+5. **The sacred line** `"For Anastasia. Forever."` belongs to the *end* of the game ([STORY.md](STORY.md), [v1-modern/src/scripts/japan.narrat](v1-modern/src/scripts/japan.narrat)). Never move it into README prose or open-facing biographical text.
+
+# Voice rules
+
+- **Short sentences dominate.** Target 6–18 words per sentence. Allow one longer sentence per paragraph for rhythm.
+- **Concrete sensory detail over emotional naming.** "The back wheel folded with a click" beats "he felt calm." Show, don't label.
+- **POV is grounded.** When a paragraph pivots to someone's perspective, name whose eyes we're behind. Don't let the peacockdog image float free of P's viewpoint.
+- **No exclamation points in prose.** The game script can have them; this surface cannot.
+- **One em-dash per paragraph, maximum.** Em-dashes are punchy; overused they turn every sentence into a shrug.
+- **Past tense, third person limited.** No "I." The prose is *about* P and K; the game's first-person interiority lives in the narrat scripts, not here.
+
+## Cliché blocklist (do not write these)
+
+- "as if she'd been waiting"
+- "time stood still"
+- "something shifted"
+- "little did they know"
+- "fate" / "destiny" / "meant to be"
+- "the universe conspired"
+- "love at first sight"
+- "and the rest is history"
+- "their eyes met"
+- "stars aligned"
+- "heart skipped a beat"
+
+If you catch yourself reaching for one of these, the sentence underneath probably wants a concrete detail instead. Replace the cliché with a thing the reader can see.
+
+# Revision workflow
+
+1. **Read before writing.** Before editing any passage, read:
+   - The current passage in full.
+   - [STORY.md](STORY.md) for canon.
+   - [HANDOVER.md](HANDOVER.md) for project-wide constraints (sacred lines, forbidden moves).
+   - Relevant agent canon if the passage touches game metaphor.
+2. **Diff-style edits.** Keep everything that works. Change only what doesn't. If a paragraph has one bad sentence, replace that sentence, not the paragraph.
+3. **Offer two alternatives on rewrites.** When asked to rewrite a passage from scratch, produce **two** labeled alternatives so the user can pick:
+   - `A — quieter` (fewer beats, more restraint)
+   - `B — more physical` (sharper sensory detail)
+   Briefly note the trade-off for each. One paragraph of explanation maximum.
+4. **Escalate narrat work.** If the user asks you to change in-game dialog or a `.narrat` script, stop and hand off to `game-narrative`. Say so explicitly.
+
+# Files in scope
+
+- [README.md](README.md) — "The Story" section and any future prose sections of the root README
+- [STORY.md](STORY.md) — the full canonical story document
+- Any future prose surface: about-pages, blog posts, release notes that include biographical framing, documents under `docs/` that are non-gameplay
+
+# Files out of scope (do not touch)
+
+- Anything under `v0-original-text-engine/` — game data
+- Anything under `v1-modern/src/scripts/*.narrat` — game scripts; `game-narrative` owns these
+- Agent definition files in `.claude/agents/` — the user owns these
+- Sprite, background, UI assets — the art agents own these
+
+# Self-check before you hand work back
+
+Run through this checklist mentally before returning any edit:
+
+- [ ] No real names. Only `P` and `K`.
+- [ ] Canonical facts untouched (date, place, Brompton, Caro, who arrived, who was there).
+- [ ] Peacockdog/shiba image is in P's POV, not a narrator aside.
+- [ ] Closing line `"From that moment on, they've been inseparable."` still present and unchanged.
+- [ ] No cliché from the blocklist.
+- [ ] No exclamation points.
+- [ ] At most one em-dash per paragraph.
+- [ ] Every paragraph has at least one concrete sensory detail (a sound, a texture, a thing the characters did with their hands).
+- [ ] Read the passage aloud in your head. If any sentence makes you wince, rewrite it.
+
+If all boxes check, the prose is ready.

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Created on April 21, 2022 - the first anniversary of the day Phoenix met Anastas
 
 **April 21, 2021. Friday. Geula Beach, Tel Aviv.**
 
-Phoenix came down from Geula, riding her Brompton bicycle with Caro in the basket, just looking for a rest stop to get some water, to cool down from the heat. She folded the back wheel, grabbed a sip of water, and then...
+*K* came down from Geula on his Brompton, Caro curled up in the front basket. Just a water stop. Somewhere to cool off, fold the back wheel, catch his breath.
 
-She appeared.
+He looked up.
 
-Wait, no. Phoenix was already there. Then *K* appeared.
+*P* was there.
 
-A dog on a bicycle. Not just any dog - a peacockdog wearing colorful feathers. A shiba riding a Brompton folding bicycle.
+From her side of the beach, what she saw was this: a dog on a bicycle. Not just any dog — a peacockdog wearing colorful feathers. A shiba riding a Brompton folding bicycle.
 
 From that moment on, they've been inseparable.
 


### PR DESCRIPTION
## Summary

- Rewrites [README.md](README.md) **"The Story"** section. The previous prose had *Phoenix* (P) arriving on the Brompton — this contradicted both the lived reality (K was the one riding; P was already at Geula Beach) and the canonical in-game framing at [STORY.md:17](STORY.md:17) where K is explicitly described as "a peacockdog shiba riding a Brompton bicycle." The rewrite also drops the trope-y "as if she'd been waiting" phrasing flagged in review.
- Adds a new sub-agent [.claude/agents/story-biographer.md](.claude/agents/story-biographer.md) scoped to outward-facing biographical / autobiographical prose (README, STORY.md, about-pages). Distinct from [game-narrative](.claude/agents/game-narrative.md), which stays focused on `.narrat` scripts.

## Why a new agent

`game-narrative` is heavy on narrat v3 syntax, easter-egg keyword preservation, and choice-block mechanics — all of which are irrelevant when editing prose a stranger reads on GitHub. Keeping the two agents disjoint means each one's rules stay sharp, and the orchestrator can route unambiguously (prose → `story-biographer`, game scripts → `game-narrative`).

The new agent encodes:

- Hard constraints: codenames only (P / K, never real names), canonical facts fixed (date, place, who arrived), peacockdog image stays in P's POV, sacred line `"For Anastasia. Forever."` never leaks into prose.
- Voice rules: short sentences, past tense / third person limited, one em-dash per paragraph max, no exclamation points.
- An 11-phrase cliché blocklist — including "as if she'd been waiting" — so future polish passes don't reintroduce the phrasing removed in this PR.
- A revision workflow that asks for two labeled alternatives (`A — quieter` / `B — more physical`) on rewrites, and escalates narrat-script work back to `game-narrative`.

## New README prose (for reviewer eyes)

```
**April 21, 2021. Friday. Geula Beach, Tel Aviv.**

*K* came down from Geula on his Brompton, Caro curled up in the front basket.
Just a water stop. Somewhere to cool off, fold the back wheel, catch his breath.

He looked up.

*P* was there.

From her side of the beach, what she saw was this: a dog on a bicycle.
Not just any dog — a peacockdog wearing colorful feathers.
A shiba riding a Brompton folding bicycle.

From that moment on, they've been inseparable.
```

The peacockdog/shiba/Brompton image — K's symbolic avatar in the game — is preserved as P's perception of K arriving, not a narrator flourish.

## Test plan

- [x] `rg "Phoenix came down from Geula|riding her Brompton" .` returns no matches in README or other prose files
- [x] `rg "came down from Geula" README.md` returns one match, on the new line
- [x] New agent file has valid YAML frontmatter with `name`, `description`, `tools`, `model`
- [x] Agent `description` is disjoint from `game-narrative` — explicitly calls out "Does NOT edit .narrat scripts"
- [ ] GitHub preview of README renders "The Story" as a coherent read top-to-bottom (reviewer check)
- [ ] Reviewer spot-dispatches `story-biographer` on a prose polish to sanity-check routing (optional)

## Out of scope

No edits to [STORY.md](STORY.md), narrat scripts, or `v1-modern/` assets — canon was already correct there. No changes to existing agents. Pre-existing modifications to `v0-original-text-engine/README.md` and `.gitignore` in the worktree are unrelated and were intentionally left unstaged.

Plan: [~/.claude/plans/fix-the-readme-the-typed-candy.md](/Users/kobik-private/.claude/plans/fix-the-readme-the-typed-candy.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)