### PR TITLE
feat(ui): volume_select boot picker (closes #3)

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -3,8 +3,8 @@
   "configurations": [
     {
       "name": "pnk-preview",
-      "runtimeExecutable": "npm",
-      "runtimeArgs": ["--prefix", "v1-modern", "run", "preview", "--", "--port", "4173", "--host", "127.0.0.1"],
+      "runtimeExecutable": "sh",
+      "runtimeArgs": ["-c", "cd v1-modern && npx vite preview --port 4173 --host 127.0.0.1"],
       "port": 4173
     }
   ]

--- a/v1-modern/index.html
+++ b/v1-modern/index.html
@@ -6,23 +6,31 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>P&K Forever</title>
     <style>
+      /* Subtle mid-play deep-link to the other volume.
+         The primary picker is the in-game `volume_select` label at boot.
+         This corner chip is a backup for mid-session switching only. */
       .pnk-switcher {
         position: fixed;
-        top: 10px;
-        right: 10px;
+        top: 8px;
+        right: 8px;
         z-index: 9999;
         display: flex;
         gap: 6px;
         font-family: system-ui, sans-serif;
-        font-size: 12px;
+        font-size: 10px;
+        opacity: 0.35;
+        transition: opacity 0.2s;
+      }
+      .pnk-switcher:hover {
+        opacity: 1;
       }
       .pnk-switcher a {
-        background: rgba(0, 0, 0, 0.75);
+        background: rgba(0, 0, 0, 0.55);
         color: #fff;
-        padding: 6px 10px;
+        padding: 4px 8px;
         border-radius: 999px;
         text-decoration: none;
-        border: 1px solid rgba(255, 107, 53, 0.8);
+        border: 1px solid rgba(255, 107, 53, 0.5);
         transition: background 0.2s;
       }
       .pnk-switcher a:hover {
@@ -32,8 +40,8 @@
   </head>
   <body>
     <div id="app"></div>
-    <nav class="pnk-switcher" aria-label="Version switcher">
-      <a href="/v0-original-text-engine/" title="Play the original text adventure">Game 1 · Original Throwback</a>
+    <nav class="pnk-switcher" aria-label="Volume switcher">
+      <a href="/v0-original-text-engine/" title="Switch to Volume 1 — the original text adventure">Vol 1 · throwback</a>
     </nav>
     <script type="module" src="/src/index.ts"></script>
   </body>

--- a/v1-modern/src/index.ts
+++ b/v1-modern/src/index.ts
@@ -7,6 +7,7 @@ import {
   mountAiRibbon,
   registerAiNpcPlugin,
 } from './plugins/ai-npc-plugin';
+import { registerOpenUrlPlugin } from './plugins/open-url-plugin';
 import {
   isTesterMode,
   mountTesterRibbon,
@@ -16,6 +17,7 @@ import {
 // Register plugins BEFORE startApp so their customCommands are in the
 // narrat parser's root vocabulary when scripts are parsed.
 registerAiNpcPlugin();
+registerOpenUrlPlugin();
 registerTesterPlugin();
 
 const aiMode = isAiMode();

--- a/v1-modern/src/plugins/open-url-plugin.ts
+++ b/v1-modern/src/plugins/open-url-plugin.ts
@@ -1,0 +1,53 @@
+/**
+ * PNK Forever — open_url command
+ *
+ * Registers a narrat `CommandPlugin` that exposes one scripting command:
+ *
+ *   open_url "/some/path"
+ *
+ * Usage (`game.narrat`):
+ *
+ *   volume_select:
+ *     choice:
+ *       "Which volume would you like to play?"
+ *       "Volume 1 · Original Throwback":
+ *         open_url "/v0-original-text-engine/index.html"
+ *       "Volume 2 · Modern Edition":
+ *         jump chapter_1_start
+ *
+ * The runner sets `window.location.href` to the arg and returns — the browser
+ * unloads the current page, so no further narrat VM work matters after the
+ * call. Matches the lifecycle shape of `tester_route`/`ai_demo_route`: a
+ * `CommandPlugin` invoked as a bare top-level command (NOT via `run`, which
+ * narrat reserves for scripted labels).
+ *
+ * Loop-invariant note (`.claude/rules/narrat-no-autoplay-loops.md`):
+ *   This command is *monotonic-advance* (pattern (b)) when used in a choice
+ *   — it transitions away from narrat entirely, so the block cannot loop on
+ *   it. No guard or flag needed. The *other* branches in the choice block
+ *   must still satisfy the invariant on their own.
+ */
+import { CommandPlugin, registerPlugin } from 'narrat';
+
+type OpenUrlArgs = { url: string };
+
+/**
+ * Registers the `open_url` plugin with narrat. Safe to call every boot.
+ */
+export function registerOpenUrlPlugin(): void {
+  const openUrl = new CommandPlugin<OpenUrlArgs, {}>(
+    'open_url',
+    [{ name: 'url', type: 'string' }],
+    async (cmd) => {
+      if (typeof window === 'undefined') return;
+      const { url } = cmd.options;
+      if (typeof url !== 'string' || url.length === 0) return;
+      window.location.href = url;
+    },
+  );
+
+  registerPlugin({
+    pluginId: 'pnk-open-url',
+    customCommands: [openUrl],
+  });
+}

--- a/v1-modern/src/scripts/game.narrat
+++ b/v1-modern/src/scripts/game.narrat
@@ -4,7 +4,15 @@ main:
   ai_demo_route
   "P. & K. — A Love Story in Two Volumes"
   ""
-  jump chapter_1_start
+  jump volume_select
+
+volume_select:
+  choice:
+    "Which volume would you like to play?"
+    "Volume 1 · Original Throwback (nostalgia — the text adventure)":
+      open_url "/v0-original-text-engine/index.html"
+    "Volume 2 · Modern Edition (new visual-novel chapters)":
+      jump chapter_1_start
 
 chapter_select:
   choice:


### PR DESCRIPTION
## Summary

Implements issue #3 — the in-game volume-select UI. On boot, players see
a narrat `choice:` prompt asking which volume they want to play, with
two pattern-(b) monotonic-advance options:

1. **Volume 1 · Original Throwback** → `open_url "/v0-original-text-engine/index.html"`
2. **Volume 2 · Modern Edition** → `jump chapter_1_start`

Follows HANDOVER.md §11.1 recipe verbatim.

## What changed

| File | Change |
|---|---|
| `v1-modern/src/plugins/open-url-plugin.ts` | NEW — registers `open_url "<path>"` custom narrat command (`window.location.href = path`) |
| `v1-modern/src/index.ts` | Register plugin BEFORE `startApp` so parser knows `open_url` vocabulary |
| `v1-modern/src/scripts/game.narrat` | `main:` final jump redirected from `chapter_select` → `volume_select`; added new `volume_select:` label |
| `v1-modern/index.html` | Corner-chip switcher toned down (opacity 0.35, smaller text, "Vol 1 · throwback") — now a backup for mid-session switching, not the primary picker |
| `.claude/launch.json` | Fix vite preview spawn (use `sh -c` + `npx` for PATH resolution) |

## Tester-route preservation

`main:` fires `tester_route` (and `ai_demo_route`) **before** `jump volume_select`, so the `?tester=1` escape hatch still short-circuits to `chapter_select` and skips the picker. Verified in preview.

## Loop-invariant compliance

Both `volume_select` options are pattern (b) monotonic-advance per `.claude/rules/narrat-no-autoplay-loops.md`:

- Vol 1: `open_url` exits the narrat runtime entirely (navigates away)
- Vol 2: `jump chapter_1_start` — forward, never back to `volume_select`

No self-jumps. Diagnostic grep unchanged from post-Phase-1 baseline.

## DoD

- [x] Build passes (`npm run build` — 1.68s)
- [x] Sacred-line count in bundle = 1 (`grep -c "For Anastasia. Forever." dist/assets/*.js`)
- [x] `volume_select` renders at boot with both options (preview verified)
- [x] Vol 2 click → Chapter 1 "Tel Aviv. A hot beach café…"
- [x] `?tester=1` still reaches `chapter_select` with all 6 chapters (Ch 6 included)
- [x] Zero console errors
- [x] Top-right corner switcher toned down

## Test plan

- [ ] CI green
- [ ] Preview deploy: landing shows volume-select picker
- [ ] Preview deploy: Vol 1 navigates to `/v0-original-text-engine/`
- [ ] Preview deploy: Vol 2 → Ch 1 intro text
- [ ] Preview deploy: `?tester=1` bypasses picker

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)