### PR TITLE
fix(narrat): close 9 rotating-choice loop-risks (closes #5, #40)

### DIFF
--- a/.claude/rules/narrat-no-autoplay-loops.md
+++ b/.claude/rules/narrat-no-autoplay-loops.md
@@ -86,7 +86,7 @@ The option jumps forward only. No flag, no loop. Used for pure navigation.
 
 ---
 
-## The three loop-smells (reject in review)
+## The four loop-smells (reject in review)
 
 1. **Unguarded set-and-return.** Option body: `set data.x true` then `jump
    <parent_label>` with **no guard** checking `data.x` at the top of the
@@ -121,6 +121,29 @@ The option jumps forward only. No flag, no loop. Used for pure navigation.
 
    *Fix:* either promote the option to pattern (b) by advancing the scene, or
    add a cascade guard so the Nth visit jumps forward.
+
+4. **Choice block with more than 6 options.** The `game-tester` caps any
+   single label at 6 visits (rotating strategy picks option N on visit N).
+   A `choice:` block with 7+ options will be visited more than 6 times before
+   all paths are covered, triggering the cap and halting the test.
+
+   *Fix:* add a pre-choice guard at the top of the label that cascades past
+   the choice block once enough topics are covered, reducing the effective
+   visit count below the cap.
+
+   *Example — `japan.narrat:kitchen_conversation` (8 options):*
+   ```narrat
+   kitchen_conversation:
+     if $data.has_necklace:
+       jump use_necklace
+     if $data.talked_zodiac:        # ← guard added per issue #40
+       jump talk_future             # cascades past the 8-option choice block
+     talk k idle "What would you like to know?"
+     choice:
+       ...
+   ```
+   The guard fires after the 6th conversational topic (`talk_zodiac`) is
+   reached, so the label is never rendered more than 6 times.
 
 ---
 

--- a/v1-modern/src/scripts/beach.narrat
+++ b/v1-modern/src/scripts/beach.narrat
@@ -8,6 +8,9 @@ beach_scene:
   set data.talked_artist false
   set data.has_shekel false
   set data.can_go_sunset false
+  set data.looked_beach false
+  set data.looked_bicycle false
+  set data.talked_bicycle false
 
   jump beach_choice
 
@@ -21,11 +24,23 @@ beach_choice:
     "Take the shekel":
       jump take_shekel
     "Look at the beach":
-      "Wide sand, turquoise water. Tel Aviv in gentle chaos behind you."
-      jump beach_choice
+      jump look_beach
     "Look at the bicycle":
-      "A BROMPTON. Folds neat as a promise."
-      jump beach_choice
+      jump look_bicycle
+
+look_beach:
+  if $data.looked_beach:
+    jump look_bicycle
+  "Wide sand, turquoise water. Tel Aviv in gentle chaos behind you."
+  set data.looked_beach true
+  jump beach_choice
+
+look_bicycle:
+  if $data.looked_bicycle:
+    jump talk_to_k
+  "A BROMPTON. Folds neat as a promise."
+  set data.looked_bicycle true
+  jump beach_choice
 
 take_shekel:
   if (== $data.has_shekel false):
@@ -45,10 +60,16 @@ talk_to_k:
       set data.knows_name true
       jump talk_to_k_named
     "Your BICYCLE is cool, what is it?":
-      talk k idle "A BROMPTON. I can fold it up and take it anywhere."
-      jump talk_to_k
+      jump talk_bicycle
     "Back":
       jump beach_choice
+
+talk_bicycle:
+  if $data.talked_bicycle:
+    jump talk_to_k_named
+  talk k idle "A BROMPTON. I can fold it up and take it anywhere."
+  set data.talked_bicycle true
+  jump talk_to_k
 
 talk_to_k_named:
   if (== $data.knows_name false):

--- a/v1-modern/src/scripts/game.narrat
+++ b/v1-modern/src/scripts/game.narrat
@@ -45,6 +45,9 @@ chapter_2_start:
   set data.talked_artist true
   set data.can_go_sunset true
   set data.has_shekel true
+  set data.looked_beach true
+  set data.looked_bicycle true
+  set data.talked_bicycle true
   jump sunset_scene
 
 chapter_3_start:
@@ -56,6 +59,9 @@ chapter_3_start:
   set data.talked_artist true
   set data.can_go_sunset true
   set data.has_shekel true
+  set data.looked_beach true
+  set data.looked_bicycle true
+  set data.talked_bicycle true
   set data.talked_food true
   set data.talked_mango true
   set data.talked_drink true
@@ -69,6 +75,11 @@ chapter_3_start:
   set data.talked_china false
   set data.agreed_to_travel true
   set data.can_fly true
+  set data.world_germany true
+  set data.world_india true
+  set data.world_france true
+  set data.world_italy true
+  set data.world_usa true
   jump jaffa_apt_scene
 
 chapter_4_start:
@@ -80,6 +91,9 @@ chapter_4_start:
   set data.talked_artist true
   set data.can_go_sunset true
   set data.has_shekel true
+  set data.looked_beach true
+  set data.looked_bicycle true
+  set data.talked_bicycle true
   set data.talked_food true
   set data.talked_mango true
   set data.talked_drink true
@@ -95,6 +109,11 @@ chapter_4_start:
   set data.can_fly true
   set data.slept_with_k true
   set data.has_kite true
+  set data.world_germany true
+  set data.world_india true
+  set data.world_france true
+  set data.world_italy true
+  set data.world_usa true
   jump japan_scene
 
 chapter_5_start:

--- a/v1-modern/src/scripts/japan.narrat
+++ b/v1-modern/src/scripts/japan.narrat
@@ -69,6 +69,8 @@ kitchen_scene:
 kitchen_conversation:
   if $data.has_necklace:
     jump use_necklace
+  if $data.talked_zodiac:
+    jump talk_future
   talk k idle "What would you like to know?"
 
   choice:

--- a/v1-modern/src/scripts/sunset.narrat
+++ b/v1-modern/src/scripts/sunset.narrat
@@ -18,6 +18,11 @@ sunset_scene:
   set data.talked_china false
   set data.talked_japan false
   set data.can_fly false
+  set data.world_germany false
+  set data.world_india false
+  set data.world_france false
+  set data.world_italy false
+  set data.world_usa false
 
   jump sunset_conversation
 
@@ -139,27 +144,57 @@ sunset_world:
       set data.agreed_to_travel true
       jump sunset_fly
     "GERMANY":
-      talk k idle "Berlin? Ich bin ein Berliner."
-      talk phoenix idle "Hmm. On second thought — not Germany."
-      jump sunset_world
+      jump sunset_world_germany
     "CHINA":
       talk phoenix idle "Too big. I want somewhere we can actually live."
       set data.talked_china true
       jump sunset_world_china
     "INDIA":
-      talk k idle "The food is incredible. The rest — maybe another life."
-      jump sunset_world
+      jump sunset_world_india
     "FRANCE":
-      talk phoenix idle "Pass. You know why."
-      jump sunset_world
+      jump sunset_world_france
     "ITALY":
-      talk k idle "I love Italy. But not to live in. Not yet."
-      jump sunset_world
+      jump sunset_world_italy
     "USA":
-      talk phoenix idle "USA? Maybe. But not right now."
-      jump sunset_world
+      jump sunset_world_usa
     "Back":
       jump sunset_conversation
+
+sunset_world_germany:
+  if $data.world_germany:
+    jump sunset_world_india
+  talk k idle "Berlin? Ich bin ein Berliner."
+  talk phoenix idle "Hmm. On second thought — not Germany."
+  set data.world_germany true
+  jump sunset_world
+
+sunset_world_india:
+  if $data.world_india:
+    jump sunset_world_france
+  talk k idle "The food is incredible. The rest — maybe another life."
+  set data.world_india true
+  jump sunset_world
+
+sunset_world_france:
+  if $data.world_france:
+    jump sunset_world_italy
+  talk phoenix idle "Pass. You know why."
+  set data.world_france true
+  jump sunset_world
+
+sunset_world_italy:
+  if $data.world_italy:
+    jump sunset_world_usa
+  talk k idle "I love Italy. But not to live in. Not yet."
+  set data.world_italy true
+  jump sunset_world
+
+sunset_world_usa:
+  if $data.world_usa:
+    jump sunset_conversation
+  talk phoenix idle "USA? Maybe. But not right now."
+  set data.world_usa true
+  jump sunset_world
 
 sunset_world_china:
   choice:


### PR DESCRIPTION
## Summary

Closes both remaining narrat loop-risks from Phase 3A of the release plan:

- **Issue #5** — 8 self-jumps across beach/sunset flagged by the diagnostic grep
- **Issue #40** — \`kitchen_conversation\` in japan.narrat had an 8-option block exceeding the game-tester's 6-visit cap

All fixes follow the canonical patterns in \`.claude/rules/narrat-no-autoplay-loops.md\`.

## What changed

| File | Self-jumps fixed | Pattern |
|---|---|---|
| \`v1-modern/src/scripts/beach.narrat\` | 3 | pattern (a) cascade-via-guard |
| \`v1-modern/src/scripts/sunset.narrat\` | 5 | pattern (a) cascade-via-guard |
| \`v1-modern/src/scripts/japan.narrat\` | — (8-option cap fix) | pre-choice guard (issue #40 fix A) |
| \`v1-modern/src/scripts/game.narrat\` | — | initialize new flags in Ch2/Ch3/Ch4 entry points |
| \`.claude/rules/narrat-no-autoplay-loops.md\` | — | codify new smell #4 per issue #40 DoD |

### beach.narrat
- \`beach_choice\` "Look at the beach" / "Look at the bicycle" → new sub-labels \`look_beach\` / \`look_bicycle\` each with cascade guards. Chain: \`look_beach\` → \`look_bicycle\` → \`talk_to_k\`.
- \`talk_to_k\` "Your BICYCLE is cool" → new sub-label \`talk_bicycle\` with cascade guard to \`talk_to_k_named\`.

### sunset.narrat
Each of GERMANY / INDIA / FRANCE / ITALY / USA in \`sunset_world\` extracted to a guarded sub-label. The cascade chain exits via \`sunset_world_usa\` → \`sunset_conversation\`, breaking the \`sunset_world\` loop entirely once all five flavour options are seen.

### japan.narrat
\`\`\`narrat
kitchen_conversation:
  if \$data.has_necklace:
    jump use_necklace
  if \$data.talked_zodiac:        # ← NEW guard, per issue #40 fix A
    jump talk_future
  ...
\`\`\`
Once the player completes the 6th conversational topic (\`talk_zodiac\`), the guard bypasses the 8-option prompt on the 7th visit — keeping visit count under the game-tester's cap while preserving the narrative.

### Rule file update
Codifies new loop-smell #4 ("choice block with more than 6 options") per issue #40's DoD requirement. Uses \`kitchen_conversation\` as the canonical fix example.

## Verification

| Check | Result |
|---|---|
| Diagnostic self-jump grep | **0 hits** (was 8 on main) |
| \`npm run build\` | passes, 1.67s |
| Sacred-line count in bundle (\`dist/assets/*.js\`) | **1** (preserved) |

## Test plan

- [ ] CI green
- [ ] Re-dispatch \`game-tester\` sub-agent after merge to confirm all 6 chapters terminate via \`home_scene\` → sacred line under rotating-choice (the Phase 3 gate per the release-acceptance rule)

## Plan reference

Phase 3A of [\`~/.claude/plans/look-into-all-open-compressed-bachman.md\`]. With this merged, **zero P0/P1 \`release-gap\` issues will remain open** — unblocking the Phase-3 gate and the next release cut.

Closes #5
Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)