### PR TITLE
fix(ch6): wire epilogue bridge, Vancouver art, and tester overlay

### DIFF
--- a/v1-modern/public/data/config.yaml
+++ b/v1-modern/public/data/config.yaml
@@ -20,13 +20,13 @@ common:
     kyoto_apt: img/kyoto_apt.png
     kitchen: img/kitchen.png
     home: img/home.png
-    # Chapter 6 placeholders — real art TBD via art-director → game-artist
-    kits_beach: img/beach_rest.png
-    vancouver_apt: img/kyoto_apt.png
-    vancouver_peak: img/sunset.png
-    squamish: img/beach.png
-    north_van_persian: img/kitchen.png
-    costco_downtown: img/home.png
+    # Chapter 6 — Vancouver (painterly art shipped in PR #38)
+    kits_beach: img/kits_beach.png
+    vancouver_apt: img/vancouver_apt.png
+    vancouver_peak: img/vancouver_peak.png
+    squamish: img/squamish.png
+    north_van_persian: img/north_van_persian.png
+    costco_downtown: img/costco_downtown.png
   hudStats: {}
 
 dialoguePanel:

--- a/v1-modern/src/plugins/tester-plugin.ts
+++ b/v1-modern/src/plugins/tester-plugin.ts
@@ -109,4 +109,18 @@ export function mountTesterRibbon(): void {
       document.body.appendChild(ribbon);
     });
   }
+
+  // Hide the `.pnk-switcher` volume deep-link chip in tester mode — testers
+  // already have a dedicated chapter-picker panel; the extra overlay is
+  // noise that also collides with this ribbon in the top-right corner.
+  hideSwitcherChip();
+}
+
+function hideSwitcherChip(): void {
+  const hide = () => {
+    const el = document.querySelector<HTMLElement>('.pnk-switcher');
+    if (el) el.style.display = 'none';
+  };
+  if (document.body) hide();
+  else window.addEventListener('DOMContentLoaded', hide);
 }

--- a/v1-modern/src/scripts/game.narrat
+++ b/v1-modern/src/scripts/game.narrat
@@ -7,6 +7,7 @@ main:
   jump volume_select
 
 volume_select:
+  tester_route
   choice:
     "Which volume would you like to play?"
     "Volume 1 · Original Throwback (nostalgia — the text adventure)":

--- a/v1-modern/src/scripts/japan.narrat
+++ b/v1-modern/src/scripts/japan.narrat
@@ -177,7 +177,15 @@ use_necklace:
 fly_home:
   "You step onto the balcony. He spreads his tail. You lift off."
   "The world curves beneath you — Kyoto, then cloud, then sea."
-  jump home_scene
+  jump epilogue_bridge
+
+epilogue_bridge:
+  choice:
+    "The silver necklace warms against your chest. The story has one more chapter — if you want it."
+    "Continue to the epilogue — The West Coast Years":
+      jump vancouver_intro
+    "Come home to Tel Aviv":
+      jump home_scene
 
 home_scene:
   set_screen home

--- a/v1-modern/src/scripts/vancouver.narrat
+++ b/v1-modern/src/scripts/vancouver.narrat
@@ -94,4 +94,5 @@ vancouver_outro:
   ""
   "..."
   ""
-  "And the story keeps going."
+  "And the story keeps going — all the way home."
+  jump home_scene


### PR DESCRIPTION
## Summary

Four production bugs reported during playtest of the v1-modern build. All fixed in a single commit:

1. **Chapter 6 (Vancouver) unreachable from normal play.** `fly_home` jumped straight to `home_scene` (the sacred Tel Aviv ending), so the epilogue was orphaned — only reachable via `?tester=1` chapter picker.

2. **Ch 6 scenes rendered with Ch 1–5 art.** `config.yaml` still pointed the six Vancouver screens at placeholder backgrounds (`beach_rest`, `kyoto_apt`, `sunset`, `beach`, `kitchen`, `home`) from before [#38](https://github.com/wildcard/pnk-forever/pull/38) shipped the real painterly Vancouver art. So testers entered Ch 6 and saw Tel Aviv / Kyoto images.

3. **`vancouver_outro` dead-ended** instead of chaining back to the sacred final line.

4. **`.pnk-switcher` "Vol 1 Throwback" overlay chip visible in tester mode**, colliding with the `TESTER MODE` ribbon and offering a redundant off-ramp that testers don't need (chapter-picker already covers that affordance).

Also added a defensive `tester_route` call inside the `volume_select` label to guard against a VM-tick race where the `main:` frame can advance past the first `tester_route` before `jumpToLabel` lands.

## Changes

| File | Change |
|---|---|
| `v1-modern/src/scripts/japan.narrat` | New `epilogue_bridge` choice: continue-to-epilogue / come-home |
| `v1-modern/src/scripts/vancouver.narrat` | `vancouver_outro` now `jump home_scene` |
| `v1-modern/public/data/config.yaml` | Ch 6 screens point at real Vancouver PNGs |
| `v1-modern/src/scripts/game.narrat` | Defensive `tester_route` inside `volume_select` |
| `v1-modern/src/plugins/tester-plugin.ts` | `hideSwitcherChip()` in tester mode |

## Sacred line invariant preserved

`home_scene` still ends with `"For Anastasia. Forever."` — the only change is that `vancouver_outro` now hands off to it, so the sacred line plays exactly once whether the player takes the normal ending or the full epilogue path. See [.claude/rules/narrat-no-autoplay-loops.md](.claude/rules/narrat-no-autoplay-loops.md).

## Test plan

- [x] `npm run build` green
- [x] `?tester=1` → chapter_select renders all 6 chapters
- [x] Ch 6 backgrounds verified via `window.narrat.jump(<label>)` for all five labels: `vancouver_intro` → `kits_beach.png`, `vancouver_apt_scene` → `vancouver_apt.png`, `did_squamish` → `squamish.png`, `did_persian` → `north_van_persian.png`, `did_costco` → `costco_downtown.png`, `did_trails` → `vancouver_peak.png`
- [x] No console errors, no failed network requests
- [x] `.pnk-switcher` computed `display: none` in tester mode; visible in normal mode
- [x] Autoplay-loop invariant unchanged (no new self-jumps introduced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)