### PR TITLE
docs(readme): refresh "What's Next" for post-Ch6 shipped state

### DIFF
--- a/.claude/backlog/BACKLOG.md
+++ b/.claude/backlog/BACKLOG.md
@@ -68,6 +68,12 @@
   - added: 2026-04-20
   - source: SESSION-GAPS.md #15
 
+- [ ] **[P3] STORY.md stale "in planning" prose** — the closing paragraph still reads *"Now, years later, with Claude Code, we honor that original vision and plan what comes next"*. After the 2026-04-23 ship, this is no longer true; a one-line past-tense update would keep STORY.md consistent with the shipped README.
+  - owner: story-biographer
+  - acceptance: final paragraph of `STORY.md` reflects that v1 shipped on the fifth anniversary; no other STORY.md content touched.
+  - added: 2026-04-23
+  - source: biographer out-of-scope note during PR #52 dispatch.
+
 ---
 
 ## Open — filed from the 2026-04-20 ship-gate verdict

--- a/.claude/backlog/BACKLOG.md
+++ b/.claude/backlog/BACKLOG.md
@@ -42,10 +42,12 @@
   - completed: 2026-04-20 (shipped on main in PR #43 `915c1bb` — CI workflow + scripts/check-easter-eggs.sh; stronger than the sunset.narrat registry-comment approach originally planned).
   - source: SESSION-GAPS.md #12
 
-- [ ] **[P1] Update `README.md` "What's Next" to match shipped state** — main has since added Ch6 Vancouver (#12/#38), AI NPC plugin (#34), volume picker (#41); README needs a fresh pass.
+- [x] **[P1] Update `README.md` "What's Next" to match shipped state** — main has since added Ch6 Vancouver (#12/#38), AI NPC plugin (#34), volume picker (#41); README needs a fresh pass.
   - owner: story-biographer
   - acceptance: section reflects reality — 5 chapters + Ch6 Vancouver epilogue all shipped, volume-select + AI NPC plugin live, chapter-select hidden from main flow, Vercel deploy live at production URL.
   - added: 2026-04-20
+  - completed: 2026-04-23
+  - result: README fully updated — v1 section rewritten as SHIPPED with chapter list; "What's Next" replaced by "What's Shipped" + post-ship roadmap; Technology section replaced with actual Narrat/Vite stack; Development History updated through April 2026; Core Principles §4 and §5 corrected to past tense; project-structure tree updated to reflect v1-modern's actual layout. Commit on branch `polish/readme-refresh-post-ch6`.
   - note: deferred from 2026-04-20 producer sequence — the rewrite prepared then went stale when main merged PRs #12/#34/#38/#41/#42/#43/#44. Fresh dispatch needed.
 
 - [ ] **[P2] Upgrade keycaps from PIL-generated PNG to SVG** — crisper UI at retina zoom.

--- a/README.md
+++ b/README.md
@@ -61,8 +61,11 @@ pnk-forever/
 │   ├── easter-eggs.md           ← The game-to-reality bridges
 │   └── integrations.md          ← Technical systems & architecture
 │
-└── v1-modern/                   ← Future: Modern reimagining
-    └── (coming soon)
+└── v1-modern/                   ← Volume 2: Modern visual novel (shipped)
+    ├── public/
+    │   ├── data/config.yaml     ← Narrat config, characters, screens
+    │   └── img/                 ← Backgrounds + sprites
+    └── src/scripts/             ← 7 .narrat chapter files
 ```
 
 ---
@@ -79,21 +82,29 @@ The original game created with GitHub Copilot on the first anniversary. It tells
 
 **[Play v0 →](https://pnk-forever.vercel.app/v0-original-text-engine/)** · [source](v0-original-text-engine/)
 
-### v1: Modern Reimagining (In Planning)
+### v1: Modern Visual Novel (Shipped — April 23, 2026)
 
-**Technology:** TBD (researching modern web game engines)
-**Created With:** Claude Code (2024-2025)
-**Status:** 📋 **PLANNING**
+**Technology:** Narrat v3, TypeScript, Vite
+**Created With:** Claude Code (2025–2026)
+**Status:** 🎁 **SHIPPED**
 
-Same narrative essence, same characters, same emotional beats - but brought to life with modern web technology and smart AI integration.
+Six chapters. Real backgrounds. Character sprites. A volume picker at launch so Anastasia can choose which version she wants. The same story, told with new tools.
 
-**Goals:**
-- Preserve the story and soul
-- Enhanced presentation (visuals, sound, interactivity)
-- Smarter Easter egg system
-- Better mobile experience
-- Potential for expanded narrative (more years, more moments)
-- AI-enhanced dialogue and scenarios
+**What shipped:**
+- **Ch 1 · Meet Cute** — Tel Aviv beach café, the Brompton, the first words
+- **Ch 2 · The Sunset Walk** — south toward Jaffa, the shekel, the question about Japan
+- **Ch 3 · Jaffa Nights** — the apartment, the kite, sleeping until morning
+- **Ch 4 · Kyoto Kitchen** — three years later, dim sum, the tiger and the snake
+- **Ch 5 · Forever Home** — the necklace, the flight home, *"For Anastasia. Forever."*
+- **Ch 6 · The West Coast Years (Epilogue)** — trails, kite, Persian food, Costco runs; a chapter for what came after
+
+**Also shipped:**
+- Volume picker at game start (choose the text adventure or the visual novel)
+- AI NPC plugin (`?ai=1`) — opt-in mode where K responds with live LLM-authored lines
+- Keyword-centralization CI — a GitHub Actions workflow ensures easter-egg triggers stay in sync across all chapters
+- Tester escape hatch (`?tester=1`) — drops straight to chapter-select with narrat's debug panel
+
+**[Play v1 →](https://pnk-forever.vercel.app/)** · [source](v1-modern/)
 
 ---
 
@@ -131,20 +142,14 @@ The game is a bridge between code and reality.
 
 ### 4. Honor the Tools
 
-- **v0** was built with GitHub Copilot - the early days of AI-assisted development
-- **v1** is being planned with Claude Code - continuing the tradition
+- **v0** was built with GitHub Copilot — the early days of AI-assisted development
+- **v1** was built with Claude Code — the tradition continued, and extended
 
-There's a poetic continuity: AI helped create something deeply human, twice, years apart.
+AI helped create something deeply human, twice, years apart. The tools changed. The intention didn't.
 
 ### 5. Don't Over-Engineer
 
-The original's beauty is its simplicity:
-- No dependencies
-- No build process
-- No frameworks
-- Just HTML, JavaScript, CSS, and a story
-
-Any modernization must ask: "Does this serve the story and the player, or just the technology?"
+v0's beauty is its simplicity — no dependencies, no build step, just HTML and a story. v1 earns its build process by using it to serve the story. The question every version asks is the same: does this serve Anastasia, or does it serve the technology?
 
 ---
 
@@ -186,31 +191,21 @@ This documentation serves two purposes:
 
 **Development Assistant:** GitHub Copilot (Tab9 era)
 
-### v1 Technology (TBD - In Research)
+### v1 Technology Stack (2025–2026)
 
-**Goals:**
-- Modern web game engine (researching options)
-- Enhanced visuals while respecting the story
-- Smarter Easter egg system (backend, not exposed keys)
-- AI integration for dynamic elements
-- Mobile-first responsive design
-- Improved accessibility
+**Engine:** Narrat v3
+- TypeScript + Vite build
+- YAML-based character and screen config
+- Custom plugin system (tester escape hatch, AI NPC, `open_url` volume picker)
+- narrat's built-in dialog, choice, and data-flag system
 
-**Candidates:**
-- Phaser (popular, mature, 2D focused)
-- Ren'Py Web (visual novel oriented)
-- ink + inkjs (narrative scripting)
-- Custom React/Vue + game engine
-- Godot (web export)
-- Three.js / PixiJS (if going visual)
+**Infrastructure:**
+- Vite build → `v1-modern/dist/`
+- Vercel hosting (same deployment as v0)
+- GitHub Actions CI for easter-egg keyword integrity
+- IFTTT webhooks for easter eggs (same as v0, same event names)
 
-**Must Maintain:**
-- Browser-based (no installation)
-- Story-first focus
-- Lightweight and fast
-- Respect for the original's aesthetic
-
-**Development Assistant:** Claude Code (2024-2025)
+**Development Assistant:** Claude Code (2025–2026)
 
 ---
 
@@ -275,15 +270,16 @@ One year later, Phoenix created the game with GitHub Copilot. A way to say: "Thi
 A love letter in code. A memory made interactive.
 
 ### December 2024
-**Preservation & Planning - v1 Begins**
+**Preservation — v1 Begins**
 
-With Claude Code, the project evolves:
-1. Restructured into monorepo
-2. Original preserved with full git history
-3. Complete documentation extracted
-4. Planning the modern reimagining
+With Claude Code, the project restructures into a monorepo. v0 preserved with full git history. Documentation extracted. The modern reimagining starts in earnest.
 
-The story continues.
+### 2025–April 2026
+**v1 Ships**
+
+Six chapters built with Narrat v3 and a team of specialized sub-agents — narrative, art, UI, tester, producer. Five chapters of Volume 2, then Ch 6 (the Vancouver epilogue, a chapter for what came after Japan), then a full ship-gate pass with zero loop risks and the sacred line confirmed terminal.
+
+The game shipped on April 23, 2026 — the fifth anniversary of the day they met.
 
 ---
 
@@ -401,37 +397,30 @@ Nothing is arbitrary. Everything matters.
 
 ---
 
+## What's Shipped
+
+v1 is complete and deployed. Here is what exists in the wild as of April 23, 2026:
+
+- ✅ Monorepo with v0 preserved and full git history intact
+- ✅ Six-chapter visual novel (Narrat v3, TypeScript, Vite)
+- ✅ Volume picker at game start — one choice, two worlds
+- ✅ All six easter-egg triggers wired (`pnk_mango`, `pnk_drink`, `pnk_chocolate`, `pnk_kite`, `pnk_love`, `pnk_fly`)
+- ✅ Keyword-centralization CI — `scripts/check-easter-eggs.sh` + GitHub Actions prevent silent drift
+- ✅ AI NPC plugin — opt-in `?ai=1` mode, zero impact on the main player path
+- ✅ Tester escape hatch — `?tester=1` for QA, invisible to Anastasia
+- ✅ Ship-gate passed: all 10 acceptance criteria green, zero loop risks, sacred line verified
+
 ## What's Next
 
-### Immediate (Current)
+The game is a gift, not a product. These are things worth doing when the moment is right — not a roadmap, not a deadline.
 
-- ✅ Restructure into monorepo
-- ✅ Preserve v0 with git history
-- ✅ Extract and document complete narrative
-- ✅ Document all mechanics, characters, items, Easter eggs
-- 🔄 Research modern web game engines
-- 🔄 Design v1 architecture
-- ⏳ Plan AI integration strategy
+- **Retina keycaps** — upgrade the UI button-prompt PNGs to SVG for crisper rendering at high DPI
+- **`beach_rest.png` regen** — the café background reads generic-romantic-dusk; a midday Tel Aviv version would match the prose better
+- **Mobile viewport coverage** — the playtest harness runs desktop only; add 375px and 390px passes
+- **Audio** — ambient beds per scene (beach waves, Kyoto rain, Tel Aviv night) whenever the core loop earns it
+- **`vercel.json` → `vercel.ts`** — typed config, easier to read
 
-### v1 Development
-
-- Choose technology stack
-- Design visual style (honoring original aesthetic)
-- Implement core engine
-- Port narrative to new format
-- Enhance Easter egg system (secure backend)
-- Add new content? (More years, more moments)
-- Mobile optimization
-- Accessibility improvements
-- Beta testing with Anastasia
-- Launch
-
-### Future Possibilities
-
-- **v2+:** Continued evolution
-- **Other formats:** Visual novel? Point-and-click? Interactive fiction?
-- **Other stories:** New chapters, new adventures
-- **Community:** Tools for others to create game-to-reality experiences?
+The backlog with full acceptance criteria lives at `.claude/backlog/BACKLOG.md`.
 
 ---
 


### PR DESCRIPTION
\`[agent]\`

**Agent:** Claude Code (\`claude-opus-4-7\`)

---

## Summary

Post-ship README refresh. Dispatched \`story-biographer\` to update the README against the **actually shipped** state as of 2026-04-23 (anniversary day).

## What changed in \`README.md\`

- **Project-structure tree** — \`v1-modern/\` updated from \`(coming soon)\` to its actual layout.
- **v1 section** — rewritten from \`PLANNING\` (🔄) to \`SHIPPED\` (🎁), with a chapter-by-chapter list (Ch 1 through Ch 6) and a feature inventory (volume picker, AI NPC plugin, keyword CI, tester escape hatch).
- **Technology section** — replaced list-of-candidates (Phaser/Ren'Py/Godot/...) with the actual shipped stack (Narrat v3, TypeScript, Vite, GitHub Actions CI).
- **Core Principles §4** — \"v1 is being planned\" → \"v1 was built\" (past tense).
- **Core Principles §5** — rewritten to honor v0's simplicity while honestly acknowledging v1's build process.
- **Development History** — added \`2025–April 2026\` milestone (\"v1 Ships\"), trimmed the December 2024 entry's \"planning\" language.
- **\"What's Next\"** → split into **\"What's Shipped\"** (checkmarks against reality) + a new \"What's Next\" (5 post-ship polish items that point at \`BACKLOG.md\` as source of truth).

## What changed in \`.claude/backlog/BACKLOG.md\`

- The P1 README item marked \`[x]\` with completion date 2026-04-23 and a summary of what the refresh did.

## Sacred constraints

- Final line **\"For Anastasia. Forever.\"** quoted byte-for-byte in the new Ch 5 bullet.
- Zero changes under \`v0-original-text-engine/\`.
- No \`.narrat\` files touched.
- No secrets, no config drift.

## Out-of-scope follow-ups surfaced (not in this PR)

- **[P3]** \`STORY.md\` still says \"Now, years later, with Claude Code, we honor that original vision and plan what comes next\" — one-line past-tense update would keep STORY.md consistent with the shipped state. Filing as backlog item on merge.

## Test plan

- [x] Confirm sacred line preserved (\`grep -n \"For Anastasia\" README.md\` returns the expected 3 lines).
- [x] Confirm no \`v0-original-text-engine/\` changes (\`git diff --name-only main\` shows only README.md + BACKLOG.md).
- [ ] (Reviewer) visual pass on GitHub's rendered README.

---

<details>
<summary>Prompt used to generate this comment</summary>

\`\`\`
Post-ship README refresh PR body — polish/readme-refresh-post-ch6 → main.
\`\`\`

</details>